### PR TITLE
Update branding to VNFap and clean code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,8 @@ name: build
 
 # ------------- NOTE
 # please setup some secrets before running this workflow:
-# DOCKER_IMAGE should be the target image name on docker hub (e.g. "rustdesk/rustdesk-server-s6" )
-# DOCKER_IMAGE_CLASSIC should be the target image name on docker hub for the old build (e.g. "rustdesk/rustdesk-server" )
+# DOCKER_IMAGE should be the target image name on docker hub (e.g. "vnfap/vnfap-server-s6" )
+# DOCKER_IMAGE_CLASSIC should be the target image name on docker hub for the old build (e.g. "vnfap/vnfap-server" )
 # DOCKER_USERNAME is the username you normally use to login at https://hub.docker.com/
 # DOCKER_PASSWORD is a token you should create under "account settings / security" with read/write access
 
@@ -199,13 +199,13 @@ jobs:
         run: |
           sudo apt update
           DEBIAN_FRONTEND=noninteractive sudo apt install -y zip
-          zip ${{ matrix.job.name }}/rustdesk-server-${{ matrix.job.os }}-${{ matrix.job.name }}${{ matrix.job.suffix }}.zip ${{ matrix.job.name }}/*
+          zip ${{ matrix.job.name }}/vnfap-server-${{ matrix.job.os }}-${{ matrix.job.name }}${{ matrix.job.suffix }}.zip ${{ matrix.job.name }}/*
 
       - name: Create Release (${{ matrix.job.os }} - (${{ matrix.job.name }})
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          files: ${{ matrix.job.name }}/rustdesk-server-${{ matrix.job.os }}-${{ matrix.job.name }}${{ matrix.job.suffix }}.zip
+          files: ${{ matrix.job.name }}/vnfap-server-${{ matrix.job.os }}-${{ matrix.job.name }}${{ matrix.job.suffix }}.zip
             
   # docker build and push of single-arch images
   docker:
@@ -501,6 +501,6 @@ jobs:
         with:
           draft: true
           files: |
-            debian-build/rustdesk-server-hbbr_*_${{ matrix.job.debian_platform }}.deb
-            debian-build/rustdesk-server-hbbs_*_${{ matrix.job.debian_platform }}.deb
-            debian-build/rustdesk-server-utils_*_${{ matrix.job.debian_platform }}.deb
+            debian-build/vnfap-server-hbbr_*_${{ matrix.job.debian_platform }}.deb
+            debian-build/vnfap-server-hbbs_*_${{ matrix.job.debian_platform }}.deb
+            debian-build/vnfap-server-utils_*_${{ matrix.job.debian_platform }}.deb

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ dns-lookup = "1.0.8"
 ping = "0.4.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
-# https://github.com/rustdesk/rustdesk-server-pro/issues/189, using native-tls for better tls support
+# https://github.com/gitxstudent/vnfap-server-pro/issues/189, using native-tls for better tls support
 reqwest = { git = "https://github.com/rustdesk-org/reqwest", features = ["blocking", "socks", "json", "native-tls", "gzip"], default-features=false }
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]

--- a/README-DE.md
+++ b/README-DE.md
@@ -10,13 +10,13 @@
 
 # VNFap Server-Programm
 
-[![build](https://github.com/rustdesk/rustdesk-server/actions/workflows/build.yaml/badge.svg)](https://github.com/rustdesk/rustdesk-server/actions/workflows/build.yaml)
+[![build](https://github.com/gitxstudent/vnfap-server/actions/workflows/build.yaml/badge.svg)](https://github.com/gitxstudent/vnfap-server/actions/workflows/build.yaml)
 
-[**Herunterladen**](https://github.com/rustdesk/rustdesk-server/releases)
+[**Herunterladen**](https://github.com/gitxstudent/vnfap-server/releases)
 
 [**Handbuch**](https://vnfap.com/docs/de/self-host/)
 
-[**FAQ**](https://github.com/rustdesk/rustdesk/wiki/FAQ)
+[**FAQ**](https://github.com/gitxstudent/vnfap-server/wiki/FAQ)
 
 Hosten Sie Ihren eigenen VNFap-Server selbst, er ist kostenlos und quelloffen.
 
@@ -32,9 +32,9 @@ In target/release werden drei ausführbare Dateien erzeugt.
 - hbbr - VNFap Relay-Server
 - rustdesk-utils - VNFap CLI-Utilities
 
-[Hier](https://github.com/rustdesk/rustdesk-server/releases) finden Sie aktualisierte Binärdateien.
+[Hier](https://github.com/gitxstudent/vnfap-server/releases) finden Sie aktualisierte Binärdateien.
 
-Wenn Sie Ihren eigenen Server entwickeln wollen, könnte [rustdesk-server-demo](https://github.com/rustdesk/rustdesk-server-demo) ein besserer und einfacherer Start für Sie sein als dieses Repository.
+Wenn Sie Ihren eigenen Server entwickeln wollen, könnte [rustdesk-server-demo](https://github.com/gitxstudent/vnfap-server-demo) ein besserer und einfacherer Start für Sie sein als dieses Repository.
 
 ## Docker-Image
 
@@ -42,18 +42,18 @@ Docker-Images werden automatisch generiert und bei jedem Github-Release veröffe
 
 ### Klassisches Image
 
-Diese Images sind mit `Ubuntu 20.04` gebaut, mit dem Zusatz der wichtigen Binärdateien (`hbbr` und `hbbs`). Sie sind auf [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) mit diesen Tags verfügbar:
+Diese Images sind mit `Ubuntu 20.04` gebaut, mit dem Zusatz der wichtigen Binärdateien (`hbbr` und `hbbs`). Sie sind auf [Docker hub](https://hub.docker.com/r/vnfap/vnfap-server/) mit diesen Tags verfügbar:
 
 | Architektur | Image:Tag |
 | --- | --- |
-| amd64 | `rustdesk/rustdesk-server:latest` |
-| arm64v8 | `rustdesk/rustdesk-server:latest-arm64v8` |
+| amd64 | `vnfap/vnfap-server:latest` |
+| arm64v8 | `vnfap/vnfap-server:latest-arm64v8` |
 
 Sie können diese Images direkt mit `docker run` mit diesen Befehlen starten:
 
 ```bash
-docker run --name hbbs --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbs -r <relay-server-ip[:port]> 
-docker run --name hbbr --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbr 
+docker run --name hbbs --net=host -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbs -r <relay-server-ip[:port]> 
+docker run --name hbbr --net=host -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbr 
 ```
 
 Oder ohne `--net=host`, aber die P2P-Direktverbindung kann dann nicht funktionieren.
@@ -61,8 +61,8 @@ Oder ohne `--net=host`, aber die P2P-Direktverbindung kann dann nicht funktionie
 Bei Systemen, die SELinux verwenden, muss `/root` durch `/root:z` ersetzt werden, damit die Container korrekt laufen. Alternativ kann die SELinux-Containertrennung durch Hinzufügen der Option `--security-opt label=disable` vollständig deaktiviert werden.
 
 ```bash
-docker run --name hbbs -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbs -r <relay-server-ip[:port]> 
-docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbr 
+docker run --name hbbs -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbs -r <relay-server-ip[:port]> 
+docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbr 
 ```
 
 Der Parameter `relay-server-ip` ist die IP-Adresse (oder der DNS-Name) des Servers, auf dem diese Container laufen. Der **optionale** Parameter `port` muss verwendet werden, wenn Sie einen anderen Port als **21117** für `hbbr` verwenden.
@@ -73,7 +73,7 @@ Sie können auch Docker Compose verwenden, wobei diese Konfiguration als Vorlage
 version: '3'
 
 networks:
-  rustdesk-net:
+  vnfap-net:
     external: false
 
 services:
@@ -84,12 +84,12 @@ services:
       - 21116:21116
       - 21116:21116/udp
       - 21118:21118
-    image: rustdesk/rustdesk-server:latest
-    command: hbbs -r rustdesk.example.com:21117
+    image: vnfap/vnfap-server:latest
+    command: hbbs -r vnfap.example.com:21117
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     depends_on:
       - hbbr
     restart: unless-stopped
@@ -99,12 +99,12 @@ services:
     ports:
       - 21117:21117
       - 21119:21119
-    image: rustdesk/rustdesk-server:latest
+    image: vnfap/vnfap-server:latest
     command: hbbr
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     restart: unless-stopped
 ```
 
@@ -114,25 +114,25 @@ Bearbeiten Sie Zeile 16 so, dass sie auf Ihren Relay-Server verweist (den, der a
 
 ## S6-Overlay-basierte Images
 
-Diese Images sind mit `busybox:stable` gebaut, mit dem Zusatz Binärdateien (sowohl hbbr als auch hbbs) und [S6-overlay](https://github.com/just-containers/s6-overlay). Sie sind auf [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6/) mit diesen Tags verfügbar:
+Diese Images sind mit `busybox:stable` gebaut, mit dem Zusatz Binärdateien (sowohl hbbr als auch hbbs) und [S6-overlay](https://github.com/just-containers/s6-overlay). Sie sind auf [Docker hub](https://hub.docker.com/r/vnfap/vnfap-server-s6/) mit diesen Tags verfügbar:
 
 | Architektur | Version | Image:Tag |
 | --- | --- | --- |
-| multiarch | neueste | `rustdesk/rustdesk-server-s6:latest` |
-| amd64 | neueste | `rustdesk/rustdesk-server-s6:latest-amd64` |
-| i386 | neueste | `rustdesk/rustdesk-server-s6:latest-i386` |
-| arm64v8 | neueste | `rustdesk/rustdesk-server-s6:latest-arm64v8` |
-| armv7 | neueste | `rustdesk/rustdesk-server-s6:latest-armv7` |
-| multiarch | 2 | `rustdesk/rustdesk-server-s6:2` |
-| amd64 | 2 | `rustdesk/rustdesk-server-s6:2-amd64` |
-| i386 | 2 | `rustdesk/rustdesk-server-s6:2-i386` |
-| arm64v8 | 2 | `rustdesk/rustdesk-server-s6:2-arm64v8` |
-| armv7 | 2 | `rustdesk/rustdesk-server-s6:2-armv7` |
-| multiarch | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0` |
-| amd64 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-amd64` |
-| i386 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-i386` |
-| arm64v8 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-arm64v8` |
-| armv7 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-armv7` |
+| multiarch | neueste | `vnfap/vnfap-server-s6:latest` |
+| amd64 | neueste | `vnfap/vnfap-server-s6:latest-amd64` |
+| i386 | neueste | `vnfap/vnfap-server-s6:latest-i386` |
+| arm64v8 | neueste | `vnfap/vnfap-server-s6:latest-arm64v8` |
+| armv7 | neueste | `vnfap/vnfap-server-s6:latest-armv7` |
+| multiarch | 2 | `vnfap/vnfap-server-s6:2` |
+| amd64 | 2 | `vnfap/vnfap-server-s6:2-amd64` |
+| i386 | 2 | `vnfap/vnfap-server-s6:2-i386` |
+| arm64v8 | 2 | `vnfap/vnfap-server-s6:2-arm64v8` |
+| armv7 | 2 | `vnfap/vnfap-server-s6:2-armv7` |
+| multiarch | 2.0.0 | `vnfap/vnfap-server-s6:2.0.0` |
+| amd64 | 2.0.0 | `vnfap/vnfap-server-s6:2.0.0-amd64` |
+| i386 | 2.0.0 | `vnfap/vnfap-server-s6:2.0.0-i386` |
+| arm64v8 | 2.0.0 | `vnfap/vnfap-server-s6:2.0.0-arm64v8` |
+| armv7 | 2.0.0 | `vnfap/vnfap-server-s6:2.0.0-armv7` |
 
 Es wird dringend empfohlen, das Image `multiarch` entweder mit dem Tag `major version` oder `latest` zu verwenden.
 
@@ -141,22 +141,22 @@ Das S6-Overlay fungiert als Supervisor und hält beide Prozesse am Laufen, sodas
 Sie können diese Images direkt mit `docker run` mit diesem Befehl starten:
 
 ```bash
-docker run --name rustdesk-server \ 
+docker run --name vnfap-server \ 
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
-  -v "$PWD/data:/data" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/data:/data" -d vnfap/vnfap-server-s6:latest
 ```
 
 oder ohne `--net=host`, aber die P2P-Direktverbindung kann dann nicht funktionieren.
 
 ```bash
-docker run --name rustdesk-server \
+docker run --name vnfap-server \
   -p 21115:21115 -p 21116:21116 -p 21116:21116/udp \
   -p 21117:21117 -p 21118:21118 -p 21119:21119 \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
-  -v "$PWD/data:/data" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/data:/data" -d vnfap/vnfap-server-s6:latest
 ```
 
 Oder Sie können eine Docker Compose-Datei verwenden:
@@ -165,8 +165,8 @@ Oder Sie können eine Docker Compose-Datei verwenden:
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -174,9 +174,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
     volumes:
       - ./data:/data
@@ -205,22 +205,22 @@ Wenn Sie keine Schlüssel angeben, erzeugt `hbbs` einen für Sie und legt ihn am
 Sie können Docker-Umgebungsvariablen verwenden, um die Schlüssel zu speichern. Folgen Sie einfach diesen Beispielen:
 
 ```bash
-docker run --name rustdesk-server \ 
+docker run --name vnfap-server \ 
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
   -e "DB_URL=/db/db_v2.sqlite3" \
   -e "KEY_PRIV=FR2j78IxfwJNR+HjLluQ2Nh7eEryEeIZCwiQDPVe+PaITKyShphHAsPLn7So0OqRs92nGvSRdFJnE2MSyrKTIQ==" \
   -e "KEY_PUB=iEyskoaYRwLDy5+0qNDqkbPdpxr0kXRSZxNjEsqykyE=" \
-  -v "$PWD/db:/db" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/db:/db" -d vnfap/vnfap-server-s6:latest
 ```
 
 ```yaml
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -228,9 +228,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
       - "DB_URL=/db/db_v2.sqlite3"
       - "KEY_PRIV=FR2j78IxfwJNR+HjLluQ2Nh7eEryEeIZCwiQDPVe+PaITKyShphHAsPLn7So0OqRs92nGvSRdFJnE2MSyrKTIQ=="
@@ -249,22 +249,22 @@ Folgen Sie einfach diesem Beispiel:
 ```bash
 cat secrets/id_ed25519.pub | docker secret create key_pub -
 cat secrets/id_ed25519 | docker secret create key_priv -
-docker service create --name rustdesk-server \
+docker service create --name vnfap-server \
   --secret key_priv --secret key_pub \
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
   -e "DB_URL=/db/db_v2.sqlite3" \
   --mount "type=bind,source=$PWD/db,destination=/db" \
-  rustdesk/rustdesk-server-s6:latest
+  vnfap/vnfap-server-s6:latest
 ```
 
 ```yaml
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -272,9 +272,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
       - "DB_URL=/db/db_v2.sqlite3"
     volumes:
@@ -304,7 +304,7 @@ Mit diesem Befehl können Sie ein Schlüsselpaar erzeugen:
 Wenn Sie das Paket `rustdesk-utils` nicht auf Ihrem System installiert haben (oder dies nicht wollen), können Sie den gleichen Befehl mit Docker aufrufen:
 
 ```bash
-docker run --rm --entrypoint /usr/bin/rustdesk-utils  rustdesk/rustdesk-server-s6:latest genkeypair
+docker run --rm --entrypoint /usr/bin/rustdesk-utils  vnfap/vnfap-server-s6:latest genkeypair
 ```
 
 Die Ausgabe sieht dann etwa so aus:
@@ -316,7 +316,7 @@ Secret Key:  egAVd44u33ZEUIDTtksGcHeVeAwywarEdHmf99KM5ajwEsuG3NQFT9coAfiZ6nen4hf
 
 ## Debian-Pakete
 
-Für jede Binärdatei stehen separate Debian-Pakete zur Verfügung, die Sie in [Releases](https://github.com/rustdesk/rustdesk-server/releases) finden können.
+Für jede Binärdatei stehen separate Debian-Pakete zur Verfügung, die Sie in [Releases](https://github.com/gitxstudent/vnfap-server/releases) finden können.
 Diese Pakete sind für die folgenden Distributionen gedacht:
 
 - Ubuntu 22.04 LTS

--- a/README-NL.md
+++ b/README-NL.md
@@ -10,13 +10,13 @@
 
 # VNFap Server Programa
 
-[![build](https://github.com/rustdesk/rustdesk-server/actions/workflows/build.yaml/badge.svg)](https://github.com/rustdesk/rustdesk-server/actions/workflows/build.yaml)
+[![build](https://github.com/gitxstudent/vnfap-server/actions/workflows/build.yaml/badge.svg)](https://github.com/gitxstudent/vnfap-server/actions/workflows/build.yaml)
 
-[**Download**](https://github.com/rustdesk/rustdesk-server/releases)
+[**Download**](https://github.com/gitxstudent/vnfap-server/releases)
 
 [**Handleiding**](https://vnfap.com/docs/nl/self-host/)
 
-[**FAQ**](https://github.com/rustdesk/rustdesk/wiki/FAQ)
+[**FAQ**](https://github.com/gitxstudent/vnfap-server/wiki/FAQ)
 
 Zelf uw eigen VNFap server hosten, het is gratis en open source.
 
@@ -32,9 +32,9 @@ In target/release worden drie uitvoerbare bestanden gegenereerd.
 - hbbr - VNFap relay server
 - rustdesk-utils - VNFap CLI hulpprogramma's
 
-U kunt bijgewerkte binaries vinden op [releases](https://github.com/rustdesk/rustdesk-server/releases) pagina.
+U kunt bijgewerkte binaries vinden op [releases](https://github.com/gitxstudent/vnfap-server/releases) pagina.
 
-Als u uw eigen server wilt ontwikkelen, is [rustdesk-server-demo](https://github.com/rustdesk/rustdesk-server-demo) misschien een betere en eenvoudigere start voor u dan deze repo.
+Als u uw eigen server wilt ontwikkelen, is [rustdesk-server-demo](https://github.com/gitxstudent/vnfap-server-demo) misschien een betere en eenvoudigere start voor u dan deze repo.
 
 ## Docker bestanden (images)
 
@@ -42,18 +42,18 @@ Docker bestanden (images) worden automatisch gegenereerd en gepubliceerd bij elk
 
 ### Klassiek bestand (image)
 
-Deze bestanden (images) zijn gebouwd voor `ubuntu-20.04` met als enige toevoeging de belangrijkste binaries (`hbbr` en `hbbs`). Ze zijn beschikbaar op [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) met deze tags:
+Deze bestanden (images) zijn gebouwd voor `ubuntu-20.04` met als enige toevoeging de belangrijkste binaries (`hbbr` en `hbbs`). Ze zijn beschikbaar op [Docker hub](https://hub.docker.com/r/vnfap/vnfap-server/) met deze tags:
 
 | architectuur | image:tag |
 | --- | --- |
-| amd64 | `rustdesk/rustdesk-server:latest` |
-| arm64v8 | `rustdesk/rustdesk-server:latest-arm64v8` |
+| amd64 | `vnfap/vnfap-server:latest` |
+| arm64v8 | `vnfap/vnfap-server:latest-arm64v8` |
 
 U kunt deze bestanden (images) direct starten via `docker run` met deze commando's:
 
 ```bash
-docker run --name hbbs --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbs -r <relay-server-ip[:port]> 
-docker run --name hbbr --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbr 
+docker run --name hbbs --net=host -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbs -r <relay-server-ip[:port]> 
+docker run --name hbbr --net=host -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbr 
 ```
 
 of zonder `--net=host`, maar een directe P2P verbinding zal niet werken.
@@ -61,8 +61,8 @@ of zonder `--net=host`, maar een directe P2P verbinding zal niet werken.
 Voor systemen die SELinux gebruiken is het vervangen van `/root` door `/root:z` nodig om de containers correct te laten draaien. Als alternatief kan SELinux containerscheiding volledig worden uitgeschakeld door de optie `--security-opt label=disable` toe te voegen.
 
 ```bash
-docker run --name hbbs -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbs -r <relay-server-ip[:port]> 
-docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbr 
+docker run --name hbbs -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbs -r <relay-server-ip[:port]> 
+docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbr 
 ```
 
 De `relay-server-ip` parameter is het IP adres (of dns naam) van de server waarop deze containers draaien. De **optionele** `port` parameter moet gebruikt worden als je een andere poort dan **21117** gebruikt voor `hbbr`.
@@ -73,7 +73,7 @@ U kunt ook docker-compose gebruiken, met deze configuratie als sjabloon:
 version: '3'
 
 networks:
-  rustdesk-net:
+  vnfap-net:
     external: false
 
 services:
@@ -84,12 +84,12 @@ services:
       - 21116:21116
       - 21116:21116/udp
       - 21118:21118
-    image: rustdesk/rustdesk-server:latest
-    command: hbbs -r rustdesk.example.com:21117
+    image: vnfap/vnfap-server:latest
+    command: hbbs -r vnfap.example.com:21117
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     depends_on:
       - hbbr
     restart: unless-stopped
@@ -99,12 +99,12 @@ services:
     ports:
       - 21117:21117
       - 21119:21119
-    image: rustdesk/rustdesk-server:latest
+    image: vnfap/vnfap-server:latest
     command: hbbr
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     restart: unless-stopped
 ```
 
@@ -114,25 +114,25 @@ Bewerk regel 16 om te verwijzen naar uw relais-server (degene die luistert op po
 
 ## S6-overlay gebaseerde bestanden
 
-Deze bestanden (images) zijn gebouwd tegen `busybox:stable` met toevoeging van de binaries (zowel hbbr als hbbs) en [S6-overlay](https://github.com/just-containers/s6-overlay). Ze zijn beschikbaar op [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6/) met deze tags:
+Deze bestanden (images) zijn gebouwd tegen `busybox:stable` met toevoeging van de binaries (zowel hbbr als hbbs) en [S6-overlay](https://github.com/just-containers/s6-overlay). Ze zijn beschikbaar op [Docker hub](https://hub.docker.com/r/vnfap/vnfap-server-s6/) met deze tags:
 
 | architectuur | versie | image:tag |
 | --- | --- | --- |
-| multiarch | latest | `rustdesk/rustdesk-server-s6:latest` |
-| amd64 | latest | `rustdesk/rustdesk-server-s6:latest-amd64` |
-| i386 | latest | `rustdesk/rustdesk-server-s6:latest-i386` |
-| arm64v8 | latest | `rustdesk/rustdesk-server-s6:latest-arm64v8` |
-| armv7 | latest | `rustdesk/rustdesk-server-s6:latest-armv7` |
-| multiarch | 2 | `rustdesk/rustdesk-server-s6:2` |
-| amd64 | 2 | `rustdesk/rustdesk-server-s6:2-amd64` |
-| i386 | 2 | `rustdesk/rustdesk-server-s6:2-i386` |
-| arm64v8 | 2 | `rustdesk/rustdesk-server-s6:2-arm64v8` |
-| armv7 | 2 | `rustdesk/rustdesk-server-s6:2-armv7` |
-| multiarch | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0` |
-| amd64 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-amd64` |
-| i386 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-i386` |
-| arm64v8 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-arm64v8` |
-| armv7 | 2.0.0 | `rustdesk/rustdesk-server-s6:2.0.0-armv7` |
+| multiarch | latest | `vnfap/vnfap-server-s6:latest` |
+| amd64 | latest | `vnfap/vnfap-server-s6:latest-amd64` |
+| i386 | latest | `vnfap/vnfap-server-s6:latest-i386` |
+| arm64v8 | latest | `vnfap/vnfap-server-s6:latest-arm64v8` |
+| armv7 | latest | `vnfap/vnfap-server-s6:latest-armv7` |
+| multiarch | 2 | `vnfap/vnfap-server-s6:2` |
+| amd64 | 2 | `vnfap/vnfap-server-s6:2-amd64` |
+| i386 | 2 | `vnfap/vnfap-server-s6:2-i386` |
+| arm64v8 | 2 | `vnfap/vnfap-server-s6:2-arm64v8` |
+| armv7 | 2 | `vnfap/vnfap-server-s6:2-armv7` |
+| multiarch | 2.0.0 | `vnfap/vnfap-server-s6:2.0.0` |
+| amd64 | 2.0.0 | `vnfap/vnfap-server-s6:2.0.0-amd64` |
+| i386 | 2.0.0 | `vnfap/vnfap-server-s6:2.0.0-i386` |
+| arm64v8 | 2.0.0 | `vnfap/vnfap-server-s6:2.0.0-arm64v8` |
+| armv7 | 2.0.0 | `vnfap/vnfap-server-s6:2.0.0-armv7` |
 
 Je wordt sterk aangeraden om het `multiarch` bestand (image) te gebruiken met de `major version` of `latest` tag.
 
@@ -141,22 +141,22 @@ De S6-overlay fungeert als supervisor en houdt beide processen draaiende, dus me
 U kunt deze bestanden (images) direct starten via `docker run` met dit commando:
 
 ```bash
-docker run --name rustdesk-server \ 
+docker run --name vnfap-server \ 
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
-  -v "$PWD/data:/data" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/data:/data" -d vnfap/vnfap-server-s6:latest
 ```
 
 of zonder `--net=host`, maar een directe P2P verbinding zal niet werken.
 
 ```bash
-docker run --name rustdesk-server \
+docker run --name vnfap-server \
   -p 21115:21115 -p 21116:21116 -p 21116:21116/udp \
   -p 21117:21117 -p 21118:21118 -p 21119:21119 \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
-  -v "$PWD/data:/data" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/data:/data" -d vnfap/vnfap-server-s6:latest
 ```
 
 Of u kunt een docker-compose bestand gebruiken:
@@ -165,8 +165,8 @@ Of u kunt een docker-compose bestand gebruiken:
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -174,9 +174,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
     volumes:
       - ./data:/data
@@ -205,22 +205,22 @@ Als je geen keys opgeeft, zal `hbbs` er een voor je genereren en op de standaard
 U kunt docker omgevingsvariabelen gebruiken om de keys op te slaan. Volg gewoon deze voorbeelden:
 
 ```bash
-docker run --name rustdesk-server \ 
+docker run --name vnfap-server \ 
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
   -e "DB_URL=/db/db_v2.sqlite3" \
   -e "KEY_PRIV=FR2j78IxfwJNR+HjLluQ2Nh7eEryEeIZCwiQDPVe+PaITKyShphHAsPLn7So0OqRs92nGvSRdFJnE2MSyrKTIQ==" \
   -e "KEY_PUB=iEyskoaYRwLDy5+0qNDqkbPdpxr0kXRSZxNjEsqykyE=" \
-  -v "$PWD/db:/db" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/db:/db" -d vnfap/vnfap-server-s6:latest
 ```
 
 ```yaml
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -228,9 +228,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
       - "DB_URL=/db/db_v2.sqlite3"
       - "KEY_PRIV=FR2j78IxfwJNR+HjLluQ2Nh7eEryEeIZCwiQDPVe+PaITKyShphHAsPLn7So0OqRs92nGvSRdFJnE2MSyrKTIQ=="
@@ -249,22 +249,22 @@ Volg deze voorbeelden:
 ```bash
 cat secrets/id_ed25519.pub | docker secret create key_pub -
 cat secrets/id_ed25519 | docker secret create key_priv -
-docker service create --name rustdesk-server \
+docker service create --name vnfap-server \
   --secret key_priv --secret key_pub \
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
   -e "DB_URL=/db/db_v2.sqlite3" \
   --mount "type=bind,source=$PWD/db,destination=/db" \
-  rustdesk/rustdesk-server-s6:latest
+  vnfap/vnfap-server-s6:latest
 ```
 
 ```yaml
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -272,9 +272,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
       - "DB_URL=/db/db_v2.sqlite3"
     volumes:
@@ -304,7 +304,7 @@ U kunt dit commando gebruiken om een key paar te genereren:
 Als u het pakket `rustdesk-utils` niet op uw systeem hebt staan (of wilt), kunt u hetzelfde commando met docker uitvoeren:
 
 ```bash
-docker run --rm --entrypoint /usr/bin/rustdesk-utils  rustdesk/rustdesk-server-s6:latest genkeypair
+docker run --rm --entrypoint /usr/bin/rustdesk-utils  vnfap/vnfap-server-s6:latest genkeypair
 ```
 
 De uitvoer ziet er ongeveer zo uit:
@@ -316,7 +316,7 @@ Secret Key:  egAVd44u33ZEUIDTtksGcHeVeAwywarEdHmf99KM5ajwEsuG3NQFT9coAfiZ6nen4hf
 
 ## .deb pakketten
 
-Voor elke binary zijn aparte .deb-pakketten beschikbaar, u kunt ze vinden in de [releases](https://github.com/rustdesk/rustdesk-server/releases).
+Voor elke binary zijn aparte .deb-pakketten beschikbaar, u kunt ze vinden in de [releases](https://github.com/gitxstudent/vnfap-server/releases).
 Deze pakketten zijn bedoeld voor de volgende distributies:
 
 - Ubuntu 22.04 LTS

--- a/README-TW.md
+++ b/README-TW.md
@@ -10,13 +10,13 @@
 
 # VNFap Server Program
 
-[![build](https://github.com/rustdesk/rustdesk-server/actions/workflows/build.yaml/badge.svg)](https://github.com/rustdesk/rustdesk-server/actions/workflows/build.yaml)
+[![build](https://github.com/gitxstudent/vnfap-server/actions/workflows/build.yaml/badge.svg)](https://github.com/gitxstudent/vnfap-server/actions/workflows/build.yaml)
 
-[**下載**](https://github.com/rustdesk/rustdesk-server/releases)
+[**下載**](https://github.com/gitxstudent/vnfap-server/releases)
 
 [**說明文件**](https://vnfap.com/docs/zh-tw/self-host/)
 
-[**FAQ**](https://github.com/rustdesk/rustdesk/wiki/FAQ)
+[**FAQ**](https://github.com/gitxstudent/vnfap-server/wiki/FAQ)
 
 自行建置屬於您自己的 VNFap 伺服器，它是免費的且開源。
 
@@ -32,10 +32,10 @@ cargo build --release
 - hbbr - VNFap 中繼伺服器
 - rustdesk-utils - VNFap 命令行工具
 
-您可以在 [releases](https://github.com/rustdesk/rustdesk-server/releases) 頁面上找到更新的執行檔。
+您可以在 [releases](https://github.com/gitxstudent/vnfap-server/releases) 頁面上找到更新的執行檔。
 
 
-如果您想開發自己的伺服器，[rustdesk-server-demo](https://github.com/rustdesk/rustdesk-server-demo) 可能是一個比這個倉庫更好、更簡單的開始。
+如果您想開發自己的伺服器，[rustdesk-server-demo](https://github.com/gitxstudent/vnfap-server-demo) 可能是一個比這個倉庫更好、更簡單的開始。
 
 ## Docker 映像檔
 
@@ -43,18 +43,18 @@ Docker 映像檔會在每次 GitHub 發布時自動生成並發布。我們有�
 
 ### Classic 映像檔
 
-這些映像檔是基於 `ubuntu-20.04` 建置的，僅添加了兩個主要的執行檔（`hbbr` 和 `hbbs`）。它們可在 [Docker Hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) 上取得，帶有以下tags：
+這些映像檔是基於 `ubuntu-20.04` 建置的，僅添加了兩個主要的執行檔（`hbbr` 和 `hbbs`）。它們可在 [Docker Hub](https://hub.docker.com/r/vnfap/vnfap-server/) 上取得，帶有以下tags：
 
 | 架構    | image:tag                                 |
 | ------- | ----------------------------------------- |
-| amd64   | `rustdesk/rustdesk-server:latest`         |
-| arm64v8 | `rustdesk/rustdesk-server:latest-arm64v8` |
+| amd64   | `vnfap/vnfap-server:latest`         |
+| arm64v8 | `vnfap/vnfap-server:latest-arm64v8` |
 
 您可以使用以下指令，直接透過 ``docker run`` 來啟動這些映像檔：
 
 ```bash
-docker run --name hbbs --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbs -r <relay-server-ip[:port]> 
-docker run --name hbbr --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbr 
+docker run --name hbbs --net=host -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbs -r <relay-server-ip[:port]> 
+docker run --name hbbr --net=host -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbr 
 ```
 
 或刪去 `--net=host`， 但 P2P 直接連線會無法運作。
@@ -62,8 +62,8 @@ docker run --name hbbr --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-serv
 對於使用 SELinux 的系統，需要將 ``/root`` 替換為 ``/root:z``，以便容器正確運行。或者，也可以通過添加選項 ``--security-opt label=disable`` 完全禁用 SELinux 容器隔離。
 
 ```bash
-docker run --name hbbs -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbs -r <relay-server-ip[:port]> 
-docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbr 
+docker run --name hbbs -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbs -r <relay-server-ip[:port]> 
+docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbr 
 ```
 
 `relay-server-ip` 參數是執行這些容器的伺服器的 IP 地址（或 DNS 名稱）。如果您為 `hbbr` 使用的端口不是 **21117**，則必須使用 **可選** 的 `port` 參數。
@@ -74,7 +74,7 @@ docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d rus
 version: '3'
 
 networks:
-  rustdesk-net:
+  vnfap-net:
     external: false
 
 services:
@@ -85,12 +85,12 @@ services:
       - 21116:21116
       - 21116:21116/udp
       - 21118:21118
-    image: rustdesk/rustdesk-server:latest
-    command: hbbs -r rustdesk.example.com:21117
+    image: vnfap/vnfap-server:latest
+    command: hbbs -r vnfap.example.com:21117
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     depends_on:
       - hbbr
     restart: unless-stopped
@@ -100,12 +100,12 @@ services:
     ports:
       - 21117:21117
       - 21119:21119
-    image: rustdesk/rustdesk-server:latest
+    image: vnfap/vnfap-server:latest
     command: hbbr
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     restart: unless-stopped
 ```
 
@@ -115,25 +115,25 @@ services:
 
 ## 基於 S6-overlay 的映象檔
 
-這些映象檔是針對 `busybox:stable` 建置的，並添加了執行檔（hbbr 和 hbbs）以及 [S6-overlay](https://github.com/just-containers/s6-overlay)。 它們在以及這些 tags 在 [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6/) 可用：
+這些映象檔是針對 `busybox:stable` 建置的，並添加了執行檔（hbbr 和 hbbs）以及 [S6-overlay](https://github.com/just-containers/s6-overlay)。 它們在以及這些 tags 在 [Docker hub](https://hub.docker.com/r/vnfap/vnfap-server-s6/) 可用：
 
 | 架構      | version | image:tag                                    |
 | --------- | ------- | -------------------------------------------- |
-| multiarch | latest  | `rustdesk/rustdesk-server-s6:latest`         |
-| amd64     | latest  | `rustdesk/rustdesk-server-s6:latest-amd64`   |
-| i386      | latest  | `rustdesk/rustdesk-server-s6:latest-i386`    |
-| arm64v8   | latest  | `rustdesk/rustdesk-server-s6:latest-arm64v8` |
-| armv7     | latest  | `rustdesk/rustdesk-server-s6:latest-armv7`   |
-| multiarch | 2       | `rustdesk/rustdesk-server-s6:2`              |
-| amd64     | 2       | `rustdesk/rustdesk-server-s6:2-amd64`        |
-| i386      | 2       | `rustdesk/rustdesk-server-s6:2-i386`         |
-| arm64v8   | 2       | `rustdesk/rustdesk-server-s6:2-arm64v8`      |
-| armv7     | 2       | `rustdesk/rustdesk-server-s6:2-armv7`        |
-| multiarch | 2.0.0   | `rustdesk/rustdesk-server-s6:2.0.0`          |
-| amd64     | 2.0.0   | `rustdesk/rustdesk-server-s6:2.0.0-amd64`    |
-| i386      | 2.0.0   | `rustdesk/rustdesk-server-s6:2.0.0-i386`     |
-| arm64v8   | 2.0.0   | `rustdesk/rustdesk-server-s6:2.0.0-arm64v8`  |
-| armv7     | 2.0.0   | `rustdesk/rustdesk-server-s6:2.0.0-armv7`    |
+| multiarch | latest  | `vnfap/vnfap-server-s6:latest`         |
+| amd64     | latest  | `vnfap/vnfap-server-s6:latest-amd64`   |
+| i386      | latest  | `vnfap/vnfap-server-s6:latest-i386`    |
+| arm64v8   | latest  | `vnfap/vnfap-server-s6:latest-arm64v8` |
+| armv7     | latest  | `vnfap/vnfap-server-s6:latest-armv7`   |
+| multiarch | 2       | `vnfap/vnfap-server-s6:2`              |
+| amd64     | 2       | `vnfap/vnfap-server-s6:2-amd64`        |
+| i386      | 2       | `vnfap/vnfap-server-s6:2-i386`         |
+| arm64v8   | 2       | `vnfap/vnfap-server-s6:2-arm64v8`      |
+| armv7     | 2       | `vnfap/vnfap-server-s6:2-armv7`        |
+| multiarch | 2.0.0   | `vnfap/vnfap-server-s6:2.0.0`          |
+| amd64     | 2.0.0   | `vnfap/vnfap-server-s6:2.0.0-amd64`    |
+| i386      | 2.0.0   | `vnfap/vnfap-server-s6:2.0.0-i386`     |
+| arm64v8   | 2.0.0   | `vnfap/vnfap-server-s6:2.0.0-arm64v8`  |
+| armv7     | 2.0.0   | `vnfap/vnfap-server-s6:2.0.0-armv7`    |
 
 強烈建議您使用 `multiarch` 映象檔 可以選擇使用 `major version` 或 `latest` tags。
 
@@ -142,22 +142,22 @@ S6-overlay 在此充當監督程序，保持兩個進程運行，因此使用此
 您可以直接使用以下命令使用 `docker run` 來啟動這個映象檔：
 
 ```bash
-docker run --name rustdesk-server \ 
+docker run --name vnfap-server \ 
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
-  -v "$PWD/data:/data" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/data:/data" -d vnfap/vnfap-server-s6:latest
 ```
 
 或刪去 `--net=host`， 但 P2P 直接連線會無法運作。
 
 ```bash
-docker run --name rustdesk-server \
+docker run --name vnfap-server \
   -p 21115:21115 -p 21116:21116 -p 21116:21116/udp \
   -p 21117:21117 -p 21118:21118 -p 21119:21119 \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
-  -v "$PWD/data:/data" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/data:/data" -d vnfap/vnfap-server-s6:latest
 ```
 
 或是您可以使用 docker-compose 文件:
@@ -166,8 +166,8 @@ docker run --name rustdesk-server \
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -175,9 +175,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
     volumes:
       - ./data:/data
@@ -206,22 +206,22 @@ services:
 您可以使用 Docker 環境變數來儲存金鑰。只需按照以下範例操作：
 
 ```bash
-docker run --name rustdesk-server \ 
+docker run --name vnfap-server \ 
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
   -e "DB_URL=/db/db_v2.sqlite3" \
   -e "KEY_PRIV=FR2j78IxfwJNR+HjLluQ2Nh7eEryEeIZCwiQDPVe+PaITKyShphHAsPLn7So0OqRs92nGvSRdFJnE2MSyrKTIQ==" \
   -e "KEY_PUB=iEyskoaYRwLDy5+0qNDqkbPdpxr0kXRSZxNjEsqykyE=" \
-  -v "$PWD/db:/db" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/db:/db" -d vnfap/vnfap-server-s6:latest
 ```
 
 ```yaml
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -229,9 +229,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
       - "DB_URL=/db/db_v2.sqlite3"
       - "KEY_PRIV=FR2j78IxfwJNR+HjLluQ2Nh7eEryEeIZCwiQDPVe+PaITKyShphHAsPLn7So0OqRs92nGvSRdFJnE2MSyrKTIQ=="
@@ -250,22 +250,22 @@ services:
 ```bash
 cat secrets/id_ed25519.pub | docker secret create key_pub -
 cat secrets/id_ed25519 | docker secret create key_priv -
-docker service create --name rustdesk-server \
+docker service create --name vnfap-server \
   --secret key_priv --secret key_pub \
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
   -e "DB_URL=/db/db_v2.sqlite3" \
   --mount "type=bind,source=$PWD/db,destination=/db" \
-  rustdesk/rustdesk-server-s6:latest
+  vnfap/vnfap-server-s6:latest
 ```
 
 ```yaml
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -273,9 +273,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
       - "DB_URL=/db/db_v2.sqlite3"
     volumes:
@@ -305,7 +305,7 @@ secrets:
 如果您沒有（或不想）在系統上安裝 `rustdesk-utils` 套件，您可以使用 Docker執行相同的命令：
 
 ```bash
-docker run --rm --entrypoint /usr/bin/rustdesk-utils  rustdesk/rustdesk-server-s6:latest genkeypair
+docker run --rm --entrypoint /usr/bin/rustdesk-utils  vnfap/vnfap-server-s6:latest genkeypair
 ```
 
 輸出將類似於以下內容：
@@ -317,7 +317,7 @@ Secret Key:  egAVd44u33ZEUIDTtksGcHeVeAwywarEdHmf99KM5ajwEsuG3NQFT9coAfiZ6nen4hf
 
 ## .deb 套件
 
-每個執行檔都有單獨的 .deb 套件可供使用，您可以在 [releases](https://github.com/rustdesk/rustdesk-server/releases) 中找到它們。
+每個執行檔都有單獨的 .deb 套件可供使用，您可以在 [releases](https://github.com/gitxstudent/vnfap-server/releases) 中找到它們。
 這些套件適用於以下發行版：
 
 - Ubuntu 22.04 LTS

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -10,13 +10,13 @@
 
 # VNFap Server Program
 
-[![build](https://github.com/rustdesk/rustdesk-server/actions/workflows/build.yaml/badge.svg)](https://github.com/rustdesk/rustdesk-server/actions/workflows/build.yaml)
+[![build](https://github.com/gitxstudent/vnfap-server/actions/workflows/build.yaml/badge.svg)](https://github.com/gitxstudent/vnfap-server/actions/workflows/build.yaml)
 
-[**下载**](https://github.com/rustdesk/rustdesk-server/releases)
+[**下载**](https://github.com/gitxstudent/vnfap-server/releases)
 
 [**说明文件**](https://vnfap.com/docs/zh-cn/self-host/)
 
-[**FAQ**](https://github.com/rustdesk/rustdesk/wiki/FAQ)
+[**FAQ**](https://github.com/gitxstudent/vnfap-server/wiki/FAQ)
 
 自行搭建属于你的VNFap服务器,所有的一切都是免费且开源的
 
@@ -32,10 +32,10 @@ cargo build --release
 - hbbr - VNFap 中继服务器
 - rustdesk-utils - VNFap 命令行工具
 
-您可以在 [releases](https://github.com/rustdesk/rustdesk-server/releases) 页面中找到最新的服务端软件。
+您可以在 [releases](https://github.com/gitxstudent/vnfap-server/releases) 页面中找到最新的服务端软件。
 
 
-如果您想开发自己的服务器，[rustdesk-server-demo](https://github.com/rustdesk/rustdesk-server-demo) 应该会比直接使用这个仓库更简单快捷。
+如果您想开发自己的服务器，[rustdesk-server-demo](https://github.com/gitxstudent/vnfap-server-demo) 应该会比直接使用这个仓库更简单快捷。
 
 ## Docker 镜像
 
@@ -43,18 +43,18 @@ Docker镜像会在每次 GitHub 发布新的release版本时自动构建。我�
 
 ### Classic 传统镜像
 
-这个类型的镜像是基于 `ubuntu-20.04` 进行构建，镜像仅包含两个主要的可执行程序（`hbbr` 和 `hbbs`）。它们可以通过以下tag在 [Docker Hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) 上获得：
+这个类型的镜像是基于 `ubuntu-20.04` 进行构建，镜像仅包含两个主要的可执行程序（`hbbr` 和 `hbbs`）。它们可以通过以下tag在 [Docker Hub](https://hub.docker.com/r/vnfap/vnfap-server/) 上获得：
 
 | 架构      | image:tag                                 |
 |---------| ----------------------------------------- |
-| amd64   | `rustdesk/rustdesk-server:latest`         |
-| arm64v8 | `rustdesk/rustdesk-server:latest-arm64v8` |
+| amd64   | `vnfap/vnfap-server:latest`         |
+| arm64v8 | `vnfap/vnfap-server:latest-arm64v8` |
 
 您可以使用以下命令，直接通过 ``docker run`` 來启动这些镜像：
 
 ```bash
-docker run --name hbbs --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbs -r <relay-server-ip[:port]> 
-docker run --name hbbr --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbr 
+docker run --name hbbs --net=host -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbs -r <relay-server-ip[:port]> 
+docker run --name hbbr --net=host -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbr 
 ```
 
 或不使用 `--net=host` 参数启动， 但这样 P2P 直连功能将无法工作。
@@ -62,8 +62,8 @@ docker run --name hbbr --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-serv
 对于使用了 SELinux 的系统，您需要将 ``/root`` 替换为 ``/root:z``，以保证容器的正常运行。或者，也可以通过添加参数 ``--security-opt label=disable`` 来完全禁用 SELinux 容器隔离。
 
 ```bash
-docker run --name hbbs -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbs -r <relay-server-ip[:port]> 
-docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbr 
+docker run --name hbbs -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbs -r <relay-server-ip[:port]> 
+docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbr 
 ```
 
 `relay-server-ip` 参数是运行这些容器的服务器的 IP 地址（或 DNS 名称）。如果你不想使用 **21117** 作为 `hbbr` 的服务端口,可使用可选参数 `port` 进行指定。
@@ -74,7 +74,7 @@ docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d rus
 version: '3'
 
 networks:
-  rustdesk-net:
+  vnfap-net:
     external: false
 
 services:
@@ -85,12 +85,12 @@ services:
       - 21116:21116
       - 21116:21116/udp
       - 21118:21118
-    image: rustdesk/rustdesk-server:latest
-    command: hbbs -r rustdesk.example.com:21117
+    image: vnfap/vnfap-server:latest
+    command: hbbs -r vnfap.example.com:21117
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     depends_on:
       - hbbr
     restart: unless-stopped
@@ -100,12 +100,12 @@ services:
     ports:
       - 21117:21117
       - 21119:21119
-    image: rustdesk/rustdesk-server:latest
+    image: vnfap/vnfap-server:latest
     command: hbbr
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     restart: unless-stopped
 ```
 
@@ -115,26 +115,26 @@ services:
 
 ## 基于 S6-overlay 的镜像
 
-> 这些镜像是针对 `busybox:stable` 构建的，并添加了可执行程序（hbbr 和 hbbs）以及 [S6-overlay](https://github.com/just-containers/s6-overlay)。 它们可以使用以下tag在 [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6/) 上获取：
+> 这些镜像是针对 `busybox:stable` 构建的，并添加了可执行程序（hbbr 和 hbbs）以及 [S6-overlay](https://github.com/just-containers/s6-overlay)。 它们可以使用以下tag在 [Docker hub](https://hub.docker.com/r/vnfap/vnfap-server-s6/) 上获取：
 
 
 | 架構      | version | image:tag                                    |
 | --------- | ------- | -------------------------------------------- |
-| multiarch | latest  | `rustdesk/rustdesk-server-s6:latest`         |
-| amd64     | latest  | `rustdesk/rustdesk-server-s6:latest-amd64`   |
-| i386      | latest  | `rustdesk/rustdesk-server-s6:latest-i386`    |
-| arm64v8   | latest  | `rustdesk/rustdesk-server-s6:latest-arm64v8` |
-| armv7     | latest  | `rustdesk/rustdesk-server-s6:latest-armv7`   |
-| multiarch | 2       | `rustdesk/rustdesk-server-s6:2`              |
-| amd64     | 2       | `rustdesk/rustdesk-server-s6:2-amd64`        |
-| i386      | 2       | `rustdesk/rustdesk-server-s6:2-i386`         |
-| arm64v8   | 2       | `rustdesk/rustdesk-server-s6:2-arm64v8`      |
-| armv7     | 2       | `rustdesk/rustdesk-server-s6:2-armv7`        |
-| multiarch | 2.0.0   | `rustdesk/rustdesk-server-s6:2.0.0`          |
-| amd64     | 2.0.0   | `rustdesk/rustdesk-server-s6:2.0.0-amd64`    |
-| i386      | 2.0.0   | `rustdesk/rustdesk-server-s6:2.0.0-i386`     |
-| arm64v8   | 2.0.0   | `rustdesk/rustdesk-server-s6:2.0.0-arm64v8`  |
-| armv7     | 2.0.0   | `rustdesk/rustdesk-server-s6:2.0.0-armv7`    |
+| multiarch | latest  | `vnfap/vnfap-server-s6:latest`         |
+| amd64     | latest  | `vnfap/vnfap-server-s6:latest-amd64`   |
+| i386      | latest  | `vnfap/vnfap-server-s6:latest-i386`    |
+| arm64v8   | latest  | `vnfap/vnfap-server-s6:latest-arm64v8` |
+| armv7     | latest  | `vnfap/vnfap-server-s6:latest-armv7`   |
+| multiarch | 2       | `vnfap/vnfap-server-s6:2`              |
+| amd64     | 2       | `vnfap/vnfap-server-s6:2-amd64`        |
+| i386      | 2       | `vnfap/vnfap-server-s6:2-i386`         |
+| arm64v8   | 2       | `vnfap/vnfap-server-s6:2-arm64v8`      |
+| armv7     | 2       | `vnfap/vnfap-server-s6:2-armv7`        |
+| multiarch | 2.0.0   | `vnfap/vnfap-server-s6:2.0.0`          |
+| amd64     | 2.0.0   | `vnfap/vnfap-server-s6:2.0.0-amd64`    |
+| i386      | 2.0.0   | `vnfap/vnfap-server-s6:2.0.0-i386`     |
+| arm64v8   | 2.0.0   | `vnfap/vnfap-server-s6:2.0.0-arm64v8`  |
+| armv7     | 2.0.0   | `vnfap/vnfap-server-s6:2.0.0-armv7`    |
 
 强烈建议您使用`major version` 或 `latest` tag 的 `multiarch` 架构的镜像。
 
@@ -143,22 +143,22 @@ S6-overlay 在此处作为监控程序，用以保证两个进程的运行，因
 您可以使用 `docker run` 命令直接启动镜像，如下：
 
 ```bash
-docker run --name rustdesk-server \ 
+docker run --name vnfap-server \ 
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
-  -v "$PWD/data:/data" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/data:/data" -d vnfap/vnfap-server-s6:latest
 ```
 
 或刪去 `--net=host` 参数， 但 P2P 直连功能将无法工作。
 
 ```bash
-docker run --name rustdesk-server \
+docker run --name vnfap-server \
   -p 21115:21115 -p 21116:21116 -p 21116:21116/udp \
   -p 21117:21117 -p 21118:21118 -p 21119:21119 \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
-  -v "$PWD/data:/data" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/data:/data" -d vnfap/vnfap-server-s6:latest
 ```
 
 或着您也可以使用 docker-compose 文件:
@@ -167,8 +167,8 @@ docker run --name rustdesk-server \
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -176,9 +176,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
     volumes:
       - ./data:/data
@@ -207,22 +207,22 @@ services:
 您可以使用 Docker 环境变量來存储密钥。如下：
 
 ```bash
-docker run --name rustdesk-server \ 
+docker run --name vnfap-server \ 
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
   -e "DB_URL=/db/db_v2.sqlite3" \
   -e "KEY_PRIV=FR2j78IxfwJNR+HjLluQ2Nh7eEryEeIZCwiQDPVe+PaITKyShphHAsPLn7So0OqRs92nGvSRdFJnE2MSyrKTIQ==" \
   -e "KEY_PUB=iEyskoaYRwLDy5+0qNDqkbPdpxr0kXRSZxNjEsqykyE=" \
-  -v "$PWD/db:/db" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/db:/db" -d vnfap/vnfap-server-s6:latest
 ```
 
 ```yaml
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -230,9 +230,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
       - "DB_URL=/db/db_v2.sqlite3"
       - "KEY_PRIV=FR2j78IxfwJNR+HjLluQ2Nh7eEryEeIZCwiQDPVe+PaITKyShphHAsPLn7So0OqRs92nGvSRdFJnE2MSyrKTIQ=="
@@ -251,22 +251,22 @@ services:
 ```bash
 cat secrets/id_ed25519.pub | docker secret create key_pub -
 cat secrets/id_ed25519 | docker secret create key_priv -
-docker service create --name rustdesk-server \
+docker service create --name vnfap-server \
   --secret key_priv --secret key_pub \
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
   -e "DB_URL=/db/db_v2.sqlite3" \
   --mount "type=bind,source=$PWD/db,destination=/db" \
-  rustdesk/rustdesk-server-s6:latest
+  vnfap/vnfap-server-s6:latest
 ```
 
 ```yaml
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -274,9 +274,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
       - "DB_URL=/db/db_v2.sqlite3"
     volumes:
@@ -306,7 +306,7 @@ secrets:
 如果您沒有（或不想）在系统上安装 `rustdesk-utils` 套件，您可以使用 Docker 执行相同的命令：
 
 ```bash
-docker run --rm --entrypoint /usr/bin/rustdesk-utils  rustdesk/rustdesk-server-s6:latest genkeypair
+docker run --rm --entrypoint /usr/bin/rustdesk-utils  vnfap/vnfap-server-s6:latest genkeypair
 ```
 
 运行后的输出内容如下：
@@ -318,7 +318,7 @@ Secret Key:  egAVd44u33ZEUIDTtksGcHeVeAwywarEdHmf99KM5ajwEsuG3NQFT9coAfiZ6nen4hf
 
 ## .deb 套件
 
-每个可执行文件都有单独的 .deb 套件可供使用，您可以在 [releases](https://github.com/rustdesk/rustdesk-server/releases) 页面中找到它們。
+每个可执行文件都有单独的 .deb 套件可供使用，您可以在 [releases](https://github.com/gitxstudent/vnfap-server/releases) 页面中找到它們。
 這些套件适用于以下发行版：
 
 - Ubuntu 22.04 LTS

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 
 # VNFap Server Program
 
-[![build](https://github.com/rustdesk/rustdesk-server/actions/workflows/build.yaml/badge.svg)](https://github.com/rustdesk/rustdesk-server/actions/workflows/build.yaml)
+[![build](https://github.com/gitxstudent/vnfap-server/actions/workflows/build.yaml/badge.svg)](https://github.com/gitxstudent/vnfap-server/actions/workflows/build.yaml)
 
-[**Download**](https://github.com/rustdesk/rustdesk-server/releases)
+[**Download**](https://github.com/gitxstudent/vnfap-server/releases)
 
 [**Manual**](https://vnfap.com/docs/en/self-host/)
 
-[**FAQ**](https://github.com/rustdesk/rustdesk/wiki/FAQ)
+[**FAQ**](https://github.com/gitxstudent/vnfap-server/wiki/FAQ)
 
 Self-host your own VNFap server, it is free and open source.
 
@@ -32,18 +32,18 @@ Three executables will be generated in target/release.
 - hbbr - VNFap relay server
 - rustdesk-utils - VNFap CLI utilities
 
-You can find updated binaries on the [Releases](https://github.com/rustdesk/rustdesk-server/releases) page.
+You can find updated binaries on the [Releases](https://github.com/gitxstudent/vnfap-server/releases) page.
 
 
-If you want to develop your own server, [rustdesk-server-demo](https://github.com/rustdesk/rustdesk-server-demo) might be a better and simpler start for you than this repo.
+If you want to develop your own server, [rustdesk-server-demo](https://github.com/gitxstudent/vnfap-server-demo) might be a better and simpler start for you than this repo.
 
 ## Docker images
 
-Docker images are automatically generated and published to [Docker Hub](https://hub.docker.com/r/rustdesk) and [GitHub Container Registry](https://github.com/rustdesk?tab=packages&repo_name=rustdesk-server) on every GitHub release. We have 2 kind of images.
+Docker images are automatically generated and published to [Docker Hub](https://hub.docker.com/r/vnfap) and [GitHub Container Registry](https://github.com/gitxstudent?tab=packages&repo_name=vnfap-server) on every GitHub release. We have 2 kind of images.
 
 ### Classic image
 
-These images are built from scratch with two main binaries (`hbbs` and `hbbr`). They're available on [Docker Hub](https://hub.docker.com/r/rustdesk/rustdesk-server/) and [GitHub Container Registry](https://github.com/rustdesk/rustdesk-server/pkgs/container/rustdesk-server) with these architectures:
+These images are built from scratch with two main binaries (`hbbs` and `hbbr`). They're available on [Docker Hub](https://hub.docker.com/r/vnfap/vnfap-server/) and [GitHub Container Registry](https://github.com/gitxstudent/vnfap-server/pkgs/container/vnfap-server) with these architectures:
 
 * amd64
 * arm64v8
@@ -53,15 +53,15 @@ You could use `latest` tag or major version tag `1` with supported architectures
 
 | Version       | image:tag                         |
 | ------------- | --------------------------------- |
-| latest        | `rustdesk/rustdesk-server:latest` |
-| Major version | `rustdesk/rustdesk-server:1`      |
+| latest        | `vnfap/vnfap-server:latest` |
+| Major version | `vnfap/vnfap-server:1`      |
 
 
 You can start these images directly with `docker run` with these commands:
 
 ```bash
-docker run --name hbbs --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbs -r <relay-server-ip[:port]> 
-docker run --name hbbr --net=host -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbr 
+docker run --name hbbs --net=host -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbs -r <relay-server-ip[:port]> 
+docker run --name hbbr --net=host -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbr 
 ```
 
 or without `--net=host`, but P2P direct connection can not work.
@@ -69,8 +69,8 @@ or without `--net=host`, but P2P direct connection can not work.
 For systems using SELinux, replacing `/root` by `/root:z` is required for the containers to run correctly. Alternatively, SELinux container separation can be disabled completely adding the option `--security-opt label=disable`.
 
 ```bash
-docker run --name hbbs -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbs -r <relay-server-ip[:port]> 
-docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d rustdesk/rustdesk-server:latest hbbr 
+docker run --name hbbs -p 21115:21115 -p 21116:21116 -p 21116:21116/udp -p 21118:21118 -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbs -r <relay-server-ip[:port]> 
+docker run --name hbbr -p 21117:21117 -p 21119:21119 -v "$PWD/data:/root" -d vnfap/vnfap-server:latest hbbr 
 ```
 
 The `relay-server-ip` parameter is the IP address (or dns name) of the server running these containers. The **optional** `port` parameter has to be used if you use a port different than **21117** for `hbbr`.
@@ -81,7 +81,7 @@ You can also use docker-compose, using this configuration as a template:
 version: '3'
 
 networks:
-  rustdesk-net:
+  vnfap-net:
     external: false
 
 services:
@@ -92,12 +92,12 @@ services:
       - 21116:21116
       - 21116:21116/udp
       - 21118:21118
-    image: rustdesk/rustdesk-server:latest
-    command: hbbs -r rustdesk.example.com:21117
+    image: vnfap/vnfap-server:latest
+    command: hbbs -r vnfap.example.com:21117
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     depends_on:
       - hbbr
     restart: unless-stopped
@@ -107,12 +107,12 @@ services:
     ports:
       - 21117:21117
       - 21119:21119
-    image: rustdesk/rustdesk-server:latest
+    image: vnfap/vnfap-server:latest
     command: hbbr
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     restart: unless-stopped
 ```
 
@@ -121,14 +121,14 @@ Edit line 16 to point to your relay server (the one listening on port 21117). Yo
 (docker-compose credit goes to @lukebarone and @QuiGonLeong)
 
 > [!NOTE]  
-> The rustdesk/rustdesk-server:latest in China may be replaced with the latest version number on Docker Hub, such as `rustdesk-server:1.1.10-3`. Otherwise, the old version may be pulled due to image acceleration.
+> The vnfap/vnfap-server:latest in China may be replaced with the latest version number on Docker Hub, such as `vnfap-server:1.1.10-3`. Otherwise, the old version may be pulled due to image acceleration.
 
 > [!NOTE]  
-> If you are experiencing issues pulling from Docker Hub, try pulling from the [GitHub Container Registry](https://github.com/rustdesk/rustdesk-server/pkgs/container/rustdesk-server) instead.
+> If you are experiencing issues pulling from Docker Hub, try pulling from the [GitHub Container Registry](https://github.com/gitxstudent/vnfap-server/pkgs/container/vnfap-server) instead.
 
 ## S6-overlay based images
 
-These images are build against `busybox:stable` with the addition of the binaries (both `hbbs` and `hbbr`) and [S6-overlay](https://github.com/just-containers/s6-overlay). They're available on [Docker hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6/) and [GitHub Container Registry](https://github.com/rustdesk/rustdesk-server/pkgs/container/rustdesk-server) with these architectures:
+These images are build against `busybox:stable` with the addition of the binaries (both `hbbs` and `hbbr`) and [S6-overlay](https://github.com/just-containers/s6-overlay). They're available on [Docker hub](https://hub.docker.com/r/vnfap/vnfap-server-s6/) and [GitHub Container Registry](https://github.com/gitxstudent/vnfap-server/pkgs/container/vnfap-server) with these architectures:
 
 * amd64
 * i386
@@ -139,30 +139,30 @@ You could use `latest` tag or major version tag `1` with supported architectures
 
 | Version       | image:tag                            |
 | ------------- | ------------------------------------ |
-| latest        | `rustdesk/rustdesk-server-s6:latest` |
-| Major version | `rustdesk/rustdesk-server-s6:1`      |
+| latest        | `vnfap/vnfap-server-s6:latest` |
+| Major version | `vnfap/vnfap-server-s6:1`      |
 
 The S6-overlay acts as a supervisor and keeps both process running, so with this image, there's no need to have two separate running containers.
 
 You can start these images directly with `docker run` with this command:
 
 ```bash
-docker run --name rustdesk-server \ 
+docker run --name vnfap-server \ 
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
-  -v "$PWD/data:/data" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/data:/data" -d vnfap/vnfap-server-s6:latest
 ```
 
 or without `--net=host`, but P2P direct connection cannot work.
 
 ```bash
-docker run --name rustdesk-server \
+docker run --name vnfap-server \
   -p 21115:21115 -p 21116:21116 -p 21116:21116/udp \
   -p 21117:21117 -p 21118:21118 -p 21119:21119 \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
-  -v "$PWD/data:/data" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/data:/data" -d vnfap/vnfap-server-s6:latest
 ```
 
 Or you can use a docker-compose file:
@@ -171,8 +171,8 @@ Or you can use a docker-compose file:
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -180,9 +180,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
     volumes:
       - ./data:/data
@@ -211,22 +211,22 @@ If you provide no keys, `hbbs` will generate one for you, and it'll place it in 
 You can use docker environment variables to store the keys. Just follow this examples:
 
 ```bash
-docker run --name rustdesk-server \ 
+docker run --name vnfap-server \ 
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
   -e "DB_URL=/db/db_v2.sqlite3" \
   -e "KEY_PRIV=FR2j78IxfwJNR+HjLluQ2Nh7eEryEeIZCwiQDPVe+PaITKyShphHAsPLn7So0OqRs92nGvSRdFJnE2MSyrKTIQ==" \
   -e "KEY_PUB=iEyskoaYRwLDy5+0qNDqkbPdpxr0kXRSZxNjEsqykyE=" \
-  -v "$PWD/db:/db" -d rustdesk/rustdesk-server-s6:latest
+  -v "$PWD/db:/db" -d vnfap/vnfap-server-s6:latest
 ```
 
 ```yaml
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -234,9 +234,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
       - "DB_URL=/db/db_v2.sqlite3"
       - "KEY_PRIV=FR2j78IxfwJNR+HjLluQ2Nh7eEryEeIZCwiQDPVe+PaITKyShphHAsPLn7So0OqRs92nGvSRdFJnE2MSyrKTIQ=="
@@ -255,22 +255,22 @@ Just follow this examples:
 ```bash
 cat secrets/id_ed25519.pub | docker secret create key_pub -
 cat secrets/id_ed25519 | docker secret create key_priv -
-docker service create --name rustdesk-server \
+docker service create --name vnfap-server \
   --secret key_priv --secret key_pub \
   --net=host \
-  -e "RELAY=rustdeskrelay.example.com" \
+  -e "RELAY=vnfaprelay.example.com" \
   -e "ENCRYPTED_ONLY=1" \
   -e "DB_URL=/db/db_v2.sqlite3" \
   --mount "type=bind,source=$PWD/db,destination=/db" \
-  rustdesk/rustdesk-server-s6:latest
+  vnfap/vnfap-server-s6:latest
 ```
 
 ```yaml
 version: '3'
 
 services:
-  rustdesk-server:
-    container_name: rustdesk-server
+  vnfap-server:
+    container_name: vnfap-server
     ports:
       - 21115:21115
       - 21116:21116
@@ -278,9 +278,9 @@ services:
       - 21117:21117
       - 21118:21118
       - 21119:21119
-    image: rustdesk/rustdesk-server-s6:latest
+    image: vnfap/vnfap-server-s6:latest
     environment:
-      - "RELAY=rustdesk.example.com:21117"
+      - "RELAY=vnfap.example.com:21117"
       - "ENCRYPTED_ONLY=1"
       - "DB_URL=/db/db_v2.sqlite3"
     volumes:
@@ -310,7 +310,7 @@ You can use this command to generate a keypair:
 If you don't have (or don't want) the `rustdesk-utils` package installed on your system, you can invoke the same command with docker:
 
 ```bash
-docker run --rm --entrypoint /usr/bin/rustdesk-utils  rustdesk/rustdesk-server-s6:latest genkeypair
+docker run --rm --entrypoint /usr/bin/rustdesk-utils  vnfap/vnfap-server-s6:latest genkeypair
 ```
 
 The output will be something like this:
@@ -322,7 +322,7 @@ Secret Key:  egAVd44u33ZEUIDTtksGcHeVeAwywarEdHmf99KM5ajwEsuG3NQFT9coAfiZ6nen4hf
 
 ## .deb packages
 
-Separate .deb packages are available for each binary, you can find them in the [Releases](https://github.com/rustdesk/rustdesk-server/releases).
+Separate .deb packages are available for each binary, you can find them in the [Releases](https://github.com/gitxstudent/vnfap-server/releases).
 These packages are meant for the following distributions:
 
 - Ubuntu 24.04 LTS

--- a/debian/rustdesk-server-hbbr.install
+++ b/debian/rustdesk-server-hbbr.install
@@ -1,2 +1,2 @@
 bin/hbbr usr/bin
-systemd/rustdesk-hbbr.service lib/systemd/system
+systemd/vnfap-hbbr.service lib/systemd/system

--- a/debian/rustdesk-server-hbbr.postinst
+++ b/debian/rustdesk-server-hbbr.postinst
@@ -1,15 +1,15 @@
 #!/bin/sh
 set -e
 
-SERVICE=rustdesk-hbbr.service
+SERVICE=vnfap-hbbr.service
 
 if [ "$1" = "configure" ]; then
-    mkdir -p /var/log/rustdesk-server
+    mkdir -p /var/log/vnfap-server
 fi
 
 case "$1" in
     configure|abort-upgrade|abort-deconfigure|abort-remove)
-      mkdir -p /var/lib/rustdesk-server/
+      mkdir -p /var/lib/vnfap-server/
 	  deb-systemd-helper unmask "${SERVICE}" >/dev/null || true
 	  if deb-systemd-helper --quiet was-enabled "${SERVICE}"; then
 	  	deb-systemd-invoke enable "${SERVICE}" >/dev/null || true

--- a/debian/rustdesk-server-hbbr.postrm
+++ b/debian/rustdesk-server-hbbr.postrm
@@ -1,12 +1,12 @@
 #!/bin/sh
 set -e
 
-SERVICE=rustdesk-hbbr.service
+SERVICE=vnfap-hbbr.service
 
 systemctl --system daemon-reload >/dev/null || true
 
 if [ "$1" = "purge" ]; then
-	rm -rf /var/log/rustdesk-server/rustdesk-hbbr.*
+	rm -rf /var/log/vnfap-server/rustdesk-hbbr.*
 	deb-systemd-helper purge "${SERVICE}" >/dev/null || true
 	deb-systemd-helper unmask "${SERVICE}" >/dev/null || true
 fi

--- a/debian/rustdesk-server-hbbr.prerm
+++ b/debian/rustdesk-server-hbbr.prerm
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-SERVICE=rustdesk-hbbr.service
+SERVICE=vnfap-hbbr.service
 
 case "$1" in
     remove|deconfigure)

--- a/debian/rustdesk-server-hbbs.install
+++ b/debian/rustdesk-server-hbbs.install
@@ -1,2 +1,2 @@
 bin/hbbs usr/bin
-systemd/rustdesk-hbbs.service lib/systemd/system
+systemd/vnfap-hbbs.service lib/systemd/system

--- a/debian/rustdesk-server-hbbs.postinst
+++ b/debian/rustdesk-server-hbbs.postinst
@@ -1,15 +1,15 @@
 #!/bin/sh
 set -e
 
-SERVICE=rustdesk-hbbs.service
+SERVICE=vnfap-hbbs.service
 
 if [ "$1" = "configure" ]; then
-    mkdir -p /var/log/rustdesk-server
+    mkdir -p /var/log/vnfap-server
 fi
 
 case "$1" in
     configure|abort-upgrade|abort-deconfigure|abort-remove)
-      mkdir -p /var/lib/rustdesk-server/
+      mkdir -p /var/lib/vnfap-server/
 	  deb-systemd-helper unmask "${SERVICE}" >/dev/null || true
 	  if deb-systemd-helper --quiet was-enabled "${SERVICE}"; then
 	  	deb-systemd-invoke enable "${SERVICE}" >/dev/null || true

--- a/debian/rustdesk-server-hbbs.postrm
+++ b/debian/rustdesk-server-hbbs.postrm
@@ -1,12 +1,12 @@
 #!/bin/sh
 set -e
 
-SERVICE=rustdesk-hbbs.service
+SERVICE=vnfap-hbbs.service
 
 systemctl --system daemon-reload >/dev/null || true
 
 if [ "$1" = "purge" ]; then
-	rm -rf /var/lib/rustdesk-server/ /var/log/rustdesk-server/rustdesk-hbbs.*
+	rm -rf /var/lib/vnfap-server/ /var/log/vnfap-server/rustdesk-hbbs.*
 	deb-systemd-helper purge "${SERVICE}" >/dev/null || true
 	deb-systemd-helper unmask "${SERVICE}" >/dev/null || true
 fi

--- a/debian/rustdesk-server-hbbs.prerm
+++ b/debian/rustdesk-server-hbbs.prerm
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-SERVICE=rustdesk-hbbs.service
+SERVICE=vnfap-hbbs.service
 
 case "$1" in
     remove|deconfigure)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 networks:
-  rustdesk-net:
+  vnfap-net:
     external: false
 
 services:
@@ -12,12 +12,12 @@ services:
       - 21116:21116
       - 21116:21116/udp
       - 21118:21118
-    image: rustdesk/rustdesk-server:latest
-    command: hbbs -r rustdesk.example.com:21117
+    image: vnfap/vnfap-server:latest
+    command: hbbs -r vnfap.example.com:21117
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     depends_on:
       - hbbr
     restart: unless-stopped
@@ -27,10 +27,10 @@ services:
     ports:
       - 21117:21117
       - 21119:21119
-    image: rustdesk/rustdesk-server:latest
+    image: vnfap/vnfap-server:latest
     command: hbbr
     volumes:
       - ./data:/root
     networks:
-      - rustdesk-net
+      - vnfap-net
     restart: unless-stopped

--- a/rcd/rustdesk-hbbr
+++ b/rcd/rustdesk-hbbr
@@ -33,7 +33,7 @@ pidfile=/var/run/rustdesk_hbbr.pid
 command=/usr/sbin/daemon
 procname=/usr/local/sbin/hbbr
 rustdesk_hbbr_chdir=/var/db/rustdesk-server
-command_args="-p ${pidfile} -o /var/log/rustdesk-hbbr.log ${procname} ${rustdesk_hbbr_args}"
+command_args="-p ${pidfile} -o /var/log/vnfap-hbbr.log ${procname} ${rustdesk_hbbr_args}"
 ## If you want the daemon do its log over syslog comment out the above line and remove the comment from the below replacement
 #command_args="-p ${pidfile} -T ${name} ${procname} ${rustdesk_hbbr_args}"
 
@@ -53,12 +53,12 @@ rustdesk_hbbr_startprecmd()
         mkdir -m 770 ${rustdesk_hbbr_chdir};
         chown ${rustdesk_hbbr_user}:${rustdesk_hbbr_group} ${rustdesk_hbbr_chdir};
     fi
-    if [ -e /var/log/rustdesk-hbbr.log ]; then
-        chown -R ${rustdesk_hbbr_user}:${rustdesk_hbbr_group} /var/log/rustdesk-hbbr.log;
-        chmod 660 /var/log/rustdesk-hbbr.log;
+    if [ -e /var/log/vnfap-hbbr.log ]; then
+        chown -R ${rustdesk_hbbr_user}:${rustdesk_hbbr_group} /var/log/vnfap-hbbr.log;
+        chmod 660 /var/log/vnfap-hbbr.log;
     else
-        install -o ${rustdesk_hbbr_user} -g ${rustdesk_hbbr_group} /dev/null /var/log/rustdesk-hbbr.log;
-        chmod 660 /var/log/rustdesk-hbbr.log;
+        install -o ${rustdesk_hbbr_user} -g ${rustdesk_hbbr_group} /dev/null /var/log/vnfap-hbbr.log;
+        chmod 660 /var/log/vnfap-hbbr.log;
     fi
 }
 

--- a/rcd/rustdesk-hbbs
+++ b/rcd/rustdesk-hbbs
@@ -36,7 +36,7 @@ pidfile=/var/run/rustdesk_hbbs.pid
 command=/usr/sbin/daemon
 procname=/usr/local/sbin/hbbs
 rustdesk_hbbs_chdir=/var/db/rustdesk-server
-command_args="-p ${pidfile} -o /var/log/rustdesk-hbbs.log ${procname} ${rustdesk_hbbs_args}"
+command_args="-p ${pidfile} -o /var/log/vnfap-hbbs.log ${procname} ${rustdesk_hbbs_args}"
 ## If you want the daemon to do its log over syslog, comment out the above line and remove the comment from the below replacement
 #command_args="-p ${pidfile} -T ${name} ${procname} ${rustdesk_hbbs_args}"
 
@@ -56,12 +56,12 @@ rustdesk_hbbs_startprecmd()
         mkdir -m 770 ${rustdesk_hbbs_chdir};
         chown ${rustdesk_hbbs_user}:${rustdesk_hbbs_group} ${rustdesk_hbbs_chdir};
     fi
-    if [ -e /var/log/rustdesk-hbbs.log ]; then
-        chown -R ${rustdesk_hbbs_user}:${rustdesk_hbbs_group} /var/log/rustdesk-hbbs.log;
-        chmod 660 /var/log/rustdesk-hbbs.log;
+    if [ -e /var/log/vnfap-hbbs.log ]; then
+        chown -R ${rustdesk_hbbs_user}:${rustdesk_hbbs_group} /var/log/vnfap-hbbs.log;
+        chmod 660 /var/log/vnfap-hbbs.log;
     else
-        install -o ${rustdesk_hbbs_user} -g ${rustdesk_hbbs_group} /dev/null /var/log/rustdesk-hbbs.log;
-        chmod 660 /var/log/rustdesk-hbbs.log;
+        install -o ${rustdesk_hbbs_user} -g ${rustdesk_hbbs_group} /dev/null /var/log/vnfap-hbbs.log;
+        chmod 660 /var/log/vnfap-hbbs.log;
     fi
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -192,9 +192,11 @@ pub async fn listen_signal() -> Result<()> {
 
 pub fn check_software_update() {
     const ONE_DAY_IN_SECONDS: u64 = 60 * 60 * 24;
-    std::thread::spawn(move || loop {
-        std::thread::spawn(move || allow_err!(check_software_update_()));
-        std::thread::sleep(std::time::Duration::from_secs(ONE_DAY_IN_SECONDS));
+    std::thread::spawn(move || {
+        loop {
+            allow_err!(check_software_update_());
+            std::thread::sleep(std::time::Duration::from_secs(ONE_DAY_IN_SECONDS));
+        }
     });
 }
 

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -515,7 +515,7 @@ impl RendezvousServer {
                     let mut msg_out = RendezvousMessage::new();
                     if !rr.relay_server.is_empty() {
                         if self.is_lan(addr_b) {
-                            // https://github.com/rustdesk/rustdesk-server/issues/24
+                            // https://github.com/gitxstudent/vnfap-server/issues/24
                             rr.relay_server = self.inner.local_ip.clone();
                         } else if rr.relay_server == self.inner.local_ip {
                             rr.relay_server = self.get_relay_server(addr.ip(), addr_b.ip());
@@ -712,7 +712,7 @@ impl RendezvousServer {
             let mut relay_server = self.get_relay_server(addr.ip(), peer_addr.ip());
             if ALWAYS_USE_RELAY.load(Ordering::SeqCst) || (peer_is_lan ^ is_lan) {
                 if peer_is_lan {
-                    // https://github.com/rustdesk/rustdesk-server/issues/24
+                    // https://github.com/gitxstudent/vnfap-server/issues/24
                     relay_server = self.inner.local_ip.clone()
                 }
                 ph.nat_type = NatType::SYMMETRIC.into(); // will force relay

--- a/systemd/vnfap-hbbr.service
+++ b/systemd/vnfap-hbbr.service
@@ -6,12 +6,12 @@ Description=VNFap Relay Server
 Type=simple
 LimitNOFILE=1000000
 ExecStart=/usr/bin/hbbr
-WorkingDirectory=/var/lib/rustdesk-server/
+WorkingDirectory=/var/lib/vnfap-server/
 User=
 Group=
 Restart=always
-StandardOutput=append:/var/log/rustdesk-server/hbbr.log
-StandardError=append:/var/log/rustdesk-server/hbbr.error
+StandardOutput=append:/var/log/vnfap-server/hbbr.log
+StandardError=append:/var/log/vnfap-server/hbbr.error
 # Restart service after 10 seconds if node service crashes
 RestartSec=10
 

--- a/systemd/vnfap-hbbs.service
+++ b/systemd/vnfap-hbbs.service
@@ -6,12 +6,12 @@ Description=VNFap Signal Server
 Type=simple
 LimitNOFILE=1000000
 ExecStart=/usr/bin/hbbs
-WorkingDirectory=/var/lib/rustdesk-server/
+WorkingDirectory=/var/lib/vnfap-server/
 User=
 Group=
 Restart=always
-StandardOutput=append:/var/log/rustdesk-server/hbbs.log
-StandardError=append:/var/log/rustdesk-server/hbbs.error
+StandardOutput=append:/var/log/vnfap-server/hbbs.log
+StandardError=append:/var/log/vnfap-server/hbbs.error
 # Restart service after 10 seconds if node service crashes
 RestartSec=10
 

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rustdesk_server"
+name = "vnfap_server"
 version = "0.1.2"
 description = "rustdesk server gui"
 authors = ["elilchen"]

--- a/ui/html/package.json
+++ b/ui/html/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rustdesk_server",
+  "name": "vnfap_server",
   "private": true,
   "version": "0.1.2",
   "type": "module",

--- a/ui/setup.nsi
+++ b/ui/setup.nsi
@@ -12,7 +12,7 @@
 # File Info
 
 !define APP_NAME "VNFapServer"
-!define PRODUCT_NAME "rustdesk_server"
+!define PRODUCT_NAME "vnfap_server"
 !define PRODUCT_DESCRIPTION "Installer for ${PRODUCT_NAME}"
 !define COPYRIGHT "Copyright © 2021"
 !define VERSION "1.1.14"

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -8,7 +8,7 @@ use async_std::{
     task::{spawn, spawn_local},
 };
 use crossbeam_channel::bounded;
-use rustdesk_server::{
+use vnfap_server::{
     usecase::{presenter, view, watcher},
     BUFFER,
 };

--- a/ui/tauri.conf.json
+++ b/ui/tauri.conf.json
@@ -7,7 +7,7 @@
     "withGlobalTauri": true
   },
   "package": {
-    "productName": "rustdesk_server",
+    "productName": "vnfap_server",
     "version": "0.1.2"
   },
   "tauri": {


### PR DESCRIPTION
## Summary
- rename systemd service files and update working directories
- change repository links and examples to new VNFap branding
- update Docker image names and network names
- optimize update check loop implementation
- rename GUI crate from `rustdesk_server` to `vnfap_server`

## Testing
- `cargo check` *(fails: failed to load manifest for dependency `hbb_common`)*

------
https://chatgpt.com/codex/tasks/task_e_684a8bd30f348320b01a00ee235c94ef