### PR TITLE
Remove RustDesk remnants

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/hbb_common"]
 	path = libs/hbb_common
-	url = https://github.com/rustdesk/hbb_common
+       url = https://github.com/gitxstudent/hbb_common

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "confy"
 version = "0.4.0-2"
-source = "git+https://github.com/rustdesk-org/confy#83db9ec19a2f97e9718aef69e4fc5611bb382479"
+source = "git+https://github.com/gitxstudent/confy#83db9ec19a2f97e9718aef69e4fc5611bb382479"
 dependencies = [
  "directories-next",
  "serde",
@@ -558,7 +558,7 @@ dependencies = [
 [[package]]
 name = "default_net"
 version = "0.1.0"
-source = "git+https://github.com/rustdesk-org/default_net#78f8f70cd85151a3a2c4a3230d80d5272703c02e"
+source = "git+https://github.com/gitxstudent/default_net#78f8f70cd85151a3a2c4a3230d80d5272703c02e"
 dependencies = [
  "anyhow",
  "regex",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "machine-uid"
 version = "0.3.0"
-source = "git+https://github.com/rustdesk-org/machine-uid#381ff579c1dc3a6c54db9dfec47c44bcb0246542"
+source = "git+https://github.com/gitxstudent/machine-uid#381ff579c1dc3a6c54db9dfec47c44bcb0246542"
 dependencies = [
  "bindgen",
  "cc",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.11.23"
-source = "git+https://github.com/rustdesk-org/reqwest#9cb758c9fb2f4edc62eb790acfd45a6a3da21ed3"
+source = "git+https://github.com/gitxstudent/reqwest#9cb758c9fb2f4edc62eb790acfd45a6a3da21ed3"
 dependencies = [
  "async-compression",
  "base64 0.21.7",
@@ -2841,7 +2841,7 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 [[package]]
 name = "sysinfo"
 version = "0.29.10"
-source = "git+https://github.com/rustdesk-org/sysinfo?branch=rlim_max#90b1705d909a4902dbbbdea37ee64db17841077d"
+source = "git+https://github.com/gitxstudent/sysinfo?branch=rlim_max#90b1705d909a4902dbbbdea37ee64db17841077d"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "tokio-socks"
 version = "0.5.2-1"
-source = "git+https://github.com/rustdesk-org/tokio-socks#94e97c6d7c93b0bcbfa54f2dc397c1da0a6e43d3"
+source = "git+https://github.com/gitxstudent/tokio-socks#94e97c6d7c93b0bcbfa54f2dc397c1da0a6e43d3"
 dependencies = [
  "bytes",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,10 +54,10 @@ ping = "0.4.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
 # https://github.com/gitxstudent/vnfap-server-pro/issues/189, using native-tls for better tls support
-reqwest = { git = "https://github.com/rustdesk-org/reqwest", features = ["blocking", "socks", "json", "native-tls", "gzip"], default-features=false }
+reqwest = { git = "https://github.com/gitxstudent/reqwest", features = ["blocking", "socks", "json", "native-tls", "gzip"], default-features=false }
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
-reqwest = { git = "https://github.com/rustdesk-org/reqwest", features = ["blocking", "socks", "json", "rustls-tls", "rustls-tls-native-roots", "gzip"], default-features=false }
+reqwest = { git = "https://github.com/gitxstudent/reqwest", features = ["blocking", "socks", "json", "rustls-tls", "rustls-tls-native-roots", "gzip"], default-features=false }
 
 [build-dependencies]
 hbb_common = { path = "libs/hbb_common" }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,43 +1,43 @@
-rustdesk-server (1.1.14) UNRELEASED; urgency=medium
+vnfap-server (1.1.14) UNRELEASED; urgency=medium
   * Fix windows crash
 
-rustdesk-server (1.1.13) UNRELEASED; urgency=medium
-  * Version check and refactor hbb_common to share with rustdesk client
+vnfap-server (1.1.13) UNRELEASED; urgency=medium
+  * Version check and refactor hbb_common to share with vnfap client
 
-rustdesk-server (1.1.12) UNRELEASED; urgency=medium
+vnfap-server (1.1.12) UNRELEASED; urgency=medium
   * WS real ip
   * Bump s6-overlay to v3.2.0.0 and fix env warnings
 
-rustdesk-server (1.1.11-1) UNRELEASED; urgency=medium
+vnfap-server (1.1.11-1) UNRELEASED; urgency=medium
   * set reuse port to make restart friendly
   * revert hbbr `-k` to not ruin back-compatibility
 
-rustdesk-server (1.1.11) UNRELEASED; urgency=medium
+vnfap-server (1.1.11) UNRELEASED; urgency=medium
   * change -k to default '-', so you need not to set -k any more
 
-rustdesk-server (1.1.10-3) UNRELEASED; urgency=medium
+vnfap-server (1.1.10-3) UNRELEASED; urgency=medium
   * fix on -2
 
-rustdesk-server (1.1.10-2) UNRELEASED; urgency=medium
+vnfap-server (1.1.10-2) UNRELEASED; urgency=medium
 
   * fix hangup signal exit when run with nohup
   * some minors
 
-rustdesk-server (1.1.9) UNRELEASED; urgency=medium
+vnfap-server (1.1.9) UNRELEASED; urgency=medium
 
   * remove unsafe
 
-rustdesk-server (1.1.8) UNRELEASED; urgency=medium
+vnfap-server (1.1.8) UNRELEASED; urgency=medium
 
   * fix test_hbbs and mask in lan
 
-rustdesk-server (1.1.7) UNRELEASED; urgency=medium
+vnfap-server (1.1.7) UNRELEASED; urgency=medium
 
   * ipv6 support
 
  -- HuyMin <info@vnfap.com>  Wed, 11 Jan 2023 11:27:00 +0800
 
-rustdesk-server (1.1.6) UNRELEASED; urgency=medium
+vnfap-server (1.1.6) UNRELEASED; urgency=medium
 
   * Initial release
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,12 @@
 use clap::App;
 use hbb_common::{
-    allow_err, anyhow::{Context, Result}, get_version_number, log, tokio, ResultType
+    allow_err,
+    anyhow::{Context, Result},
+    get_version_number,
+    log,
+    tokio,
+    ResultType,
+    VER_TYPE_RUSTDESK_SERVER as VER_TYPE_VNFAP_SERVER,
 };
 use ini::Ini;
 use sodiumoxide::crypto::sign;
@@ -202,7 +208,8 @@ pub fn check_software_update() {
 
 #[tokio::main(flavor = "current_thread")]
 async fn check_software_update_() -> hbb_common::ResultType<()> {
-    let (request, url) = hbb_common::version_check_request(hbb_common::VER_TYPE_RUSTDESK_SERVER.to_string());
+    let (request, url) =
+        hbb_common::version_check_request(VER_TYPE_VNFAP_SERVER.to_string());
     let latest_release_response = reqwest::Client::builder().build()?
         .post(url)
         .json(&request)

--- a/ui/Cargo.lock
+++ b/ui/Cargo.lock
@@ -2314,7 +2314,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustdesk_server"
+name = "vnfap_server"
 version = "0.1.2"
 dependencies = [
  "async-std",


### PR DESCRIPTION
## Summary
- rebrand leftover paths and constants to VNFap
- update changelog and submodule URL
- adjust Cargo dependencies to use gitxstudent

## Testing
- `cargo fmt` *(fails: failed to load manifest for dependency `hbb_common`)*
- `cargo check` *(fails: failed to load manifest for dependency `hbb_common`)*

------
https://chatgpt.com/codex/tasks/task_e_684a92f63de08320a29e0927e23901c6