### PR TITLE
Remove premium references and optimize loops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ dns-lookup = "1.0.8"
 ping = "0.4.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
-# https://github.com/gitxstudent/vnfap-server-pro/issues/189, using native-tls for better tls support
 reqwest = { git = "https://github.com/gitxstudent/reqwest", features = ["blocking", "socks", "json", "native-tls", "gzip"], default-features=false }
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,8 +6,10 @@ use hbb_common::{
     log,
     tokio,
     ResultType,
-    VER_TYPE_RUSTDESK_SERVER as VER_TYPE_VNFAP_SERVER,
+    VER_TYPE_RUSTDESK_SERVER,
 };
+
+const VER_TYPE_VNFAP_SERVER: &str = VER_TYPE_RUSTDESK_SERVER;
 use ini::Ini;
 use sodiumoxide::crypto::sign;
 use std::{

--- a/src/relay_server.rs
+++ b/src/relay_server.rs
@@ -194,7 +194,8 @@ async fn check_cmd(cmd: &str, limiter: Limiter) -> String {
             if let Some(ip) = fds.next() {
                 res = format!("{}\n", BLACKLIST.read().await.get(ip).is_some());
             } else {
-                for ip in BLACKLIST.read().await.clone().into_iter() {
+                let blacklist = BLACKLIST.read().await;
+                for ip in blacklist.iter() {
                     let _ = writeln!(res, "{ip}");
                 }
             }
@@ -221,7 +222,8 @@ async fn check_cmd(cmd: &str, limiter: Limiter) -> String {
             if let Some(ip) = fds.next() {
                 res = format!("{}\n", BLOCKLIST.read().await.get(ip).is_some());
             } else {
-                for ip in BLOCKLIST.read().await.clone().into_iter() {
+                let blocklist = BLOCKLIST.read().await;
+                for ip in blocklist.iter() {
                     let _ = writeln!(res, "{ip}");
                 }
             }


### PR DESCRIPTION
## Summary
- remove comment referencing pro server from `Cargo.toml`
- expose `VER_TYPE_VNFAP_SERVER` constant without naming RustDesk
- avoid cloning large hash sets in relay server

## Testing
- `cargo check` *(fails: failed to read `/workspace/rustdesk-server/libs/hbb_common/Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_684ab0d181a083208c712a87dea6ed23