### PR TITLE
Remove licence checks, update branding

### DIFF
--- a/src/relay_server.rs
+++ b/src/relay_server.rs
@@ -424,14 +424,11 @@ async fn make_pair(
     Ok(())
 }
 
-async fn make_pair_(stream: impl StreamTrait, addr: SocketAddr, key: &str, limiter: Limiter) {
+async fn make_pair_(stream: impl StreamTrait, addr: SocketAddr, _key: &str, limiter: Limiter) {
     let mut stream = stream;
     if let Ok(Some(Ok(bytes))) = timeout(30_000, stream.recv()).await {
         if let Ok(msg_in) = RendezvousMessage::parse_from_bytes(&bytes) {
             if let Some(rendezvous_message::Union::RequestRelay(rf)) = msg_in.union {
-                if !key.is_empty() && rf.licence_key != key {
-                    return;
-                }
                 if !rf.uuid.is_empty() {
                     let mut peer = PEERS.lock().await.remove(&rf.uuid);
                     if let Some(peer) = peer.as_mut() {

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -675,18 +675,10 @@ impl RendezvousServer {
         &mut self,
         addr: SocketAddr,
         ph: PunchHoleRequest,
-        key: &str,
+        _key: &str,
         ws: bool,
     ) -> ResultType<(RendezvousMessage, Option<SocketAddr>)> {
         let mut ph = ph;
-        if !key.is_empty() && ph.licence_key != key {
-            let mut msg_out = RendezvousMessage::new();
-            msg_out.set_punch_hole_response(PunchHoleResponse {
-                failure: punch_hole_response::Failure::LICENSE_MISMATCH.into(),
-                ..Default::default()
-            });
-            return Ok((msg_out, None));
-        }
         let id = ph.id;
         // punch hole request from A, relay to B,
         // check if in same intranet first,


### PR DESCRIPTION
## Summary
- drop paid licence checks from rendezvous and relay servers
- clean up signal listener implementation
- replace remaining RustDesk constant with VNFap branding

## Testing
- `cargo check` *(fails: failed to load manifest for dependency `hbb_common`)*

------
https://chatgpt.com/codex/tasks/task_e_684ab78274c88320a6cf48229c283b93